### PR TITLE
Fix: Récupération du nom du bouton cliqué

### DIFF
--- a/src/Vue.java
+++ b/src/Vue.java
@@ -55,8 +55,8 @@ public class Vue extends JFrame implements MouseListener, ActionListener{
 
 	public void actionPerformed(ActionEvent e) 
 	{
-		Object source = e.getSource();
-		System.out.println(e.equals("Button1"));
+		JButton source = (JButton)e.getSource();
+		System.out.println(source.getName());
 	}
 
 


### PR DESCRIPTION
La source est passée dans l'événement sous la forme d'un Object.
Or, pour récupérer des attributs spécifiques ou appeler des méthodes spécifiques à JButton, il faut indiquer à Java que l'Object récupéré est en fait un JButton.